### PR TITLE
Update of Automate, Apps and Dataverse best practices

### DIFF
--- a/CanvasApps.md
+++ b/CanvasApps.md
@@ -26,19 +26,50 @@ Controls should be appropriately named to describe the type and purpose of the c
 
 All control names on the canvas should use camel case. They should begin with a three-character type descriptor, followed by the purpose of the control. This approach helps identify the type of control and makes it easier to build formulas and search.
 
-| **Control Type** | **Prefix** |
-| --- | --- |
-| Button | btn |
-| Combo box | cmb |
-| Date picker | dte |
-| Drop down | drp |
-| Html text | htm |
-| Icon | ico |
-| Image | img |
-| label | lbl |
-| Shape (rectangle, circle, etc) | shp |
-| Text input | txt |
-| Timer | tim |
+|   **Control Type**                         |     **Prefix**      |
+|--------------------------------------------|---------------------|
+|     3D object                              |     tdo             |
+|     Add picture                            |     apc             |
+|     Address input                          |     adr             |
+|     Audio                                  |     aud             |
+|     Barcode   scanner                      |     bar             |
+|     Button                                 |     btn             |
+|     Camera                                 |     cam             |
+|     Canvas                                 |     can             |
+|     Charts (Pie   chart, bar chart etc)    |     chr             |
+|     Check box                              |     chk             |
+|     Combo box                              |     cmb             |
+|     Container                              |     con             |
+|     Data table                             |     tbl             |
+|     Date picker                            |     dte             |
+|     Drop down                              |     drp             |
+|     Export                                 |     exp             |
+|     Forms (New /   Edit etc)               |     frm             |
+|     Gallery                                |     gal             |
+|     Horizontal   container                 |     con             |
+|     HTML text                              |     htm             |
+|     Icon                                   |     ico             |
+|     Image                                  |     img             |
+|     Import                                 |     imp             |
+|     Label                                  |     lbl             |
+|     List box                               |     lst             |
+|     Map                                    |     map             |
+|     Measuring   camera                     |     mec             |
+|     Microphone                             |     mic             |
+|     Microsoft   Stream                     |     vid             |
+|     PDF viewer                             |     pvr             |
+|     Pen input                              |     pin             |
+|     Radio                                  |     rdo             |
+|     Rating                                 |     rtg             |
+|     Rich text   editor                     |     ric             |
+|     Shape   (Rectangle, Circle etc)        |     shp             |
+|     Slider                                 |     slr             |
+|     Text input                             |     txt             |
+|     Timer                                  |     tmr             |
+|     Toggle                                 |     tgl             |
+|     Vertical   container                   |     con             |
+|     Video                                  |     vid             |
+
 
 Control names must be unique across an application. If a control is reused on multiple screens, the short
 
@@ -61,13 +92,22 @@ Be smart! PowerApps lets context variables and global variables share the same n
 
 - Prefix context variables with loc.
 - Prefix global variables with gbl.
+- After the prefix state the data type the variable will contain with a three letter code. This ensures that if the application runs into errors related to that variable developers can quickly ascertain the expected data type.
 - The name after the prefix should indicate the intent/purpose of the variable. Multiple words can be used and don’t have to be separated by any special characters (for example, spaces or underscores), provided that the first letter of each word is capitalized.
 - Use Camel casing. Begin your variable names with a prefix in lowercase letters, and then capitalize the first letter of each word in the name (that is, lowerUppperUpper).
 
+| **Data Type**|**Code**|
+|--------------|--------|
+| String       | txt    |
+| Record       | rec    |
+| Boolean      | bol    |
+| Table        | tab    |
+| Number       | int    |
+
 Here are some good examples:
 
-- Global variable: gblFocusedBorderColor
-- Context variable: locSuccessMessage
+- Global variable: gblrecCurrentUser
+- Context variable: loctxtSuccessMessage
 
 Here are some bad examples:
 

--- a/CanvasApps.md
+++ b/CanvasApps.md
@@ -92,17 +92,19 @@ Be smart! PowerApps lets context variables and global variables share the same n
 
 - Prefix context variables with loc.
 - Prefix global variables with gbl.
-- After the prefix state the data type the variable will contain with a three letter code. This ensures that if the application runs into errors related to that variable developers can quickly ascertain the expected data type.
-- The name after the prefix should indicate the intent/purpose of the variable. Multiple words can be used and don’t have to be separated by any special characters (for example, spaces or underscores), provided that the first letter of each word is capitalized.
+- After the prefix state the data type the variable will contain with a three letter code (see table below). Variables can only hold a single data type throughout the app. If functions try to write different types to a vairable an error will occur. Stating the data type in the variable name can make it    much simpler to diagnose these errors.
+- The name after the data type should indicate the intent/purpose of the variable. Multiple words can be used and don’t have to be separated by any special characters (for example, spaces or underscores), provided that the first letter of each word is capitalized.
 - Use Camel casing. Begin your variable names with a prefix in lowercase letters, and then capitalize the first letter of each word in the name (that is, lowerUppperUpper).
+
 
 | **Data Type**|**Code**|
 |--------------|--------|
-| String       | txt    |
-| Record       | rec    |
-| Boolean      | bol    |
-| Table        | tab    |
-| Number       | int    |
+| Text         | Txt    |
+| Number       | Num    |
+| Date         | Dte    |
+| Boolean      | Bol    |
+| Record       | Rec    |
+| Table        | Tab    |
 
 Here are some good examples:
 

--- a/Dataverse.md
+++ b/Dataverse.md
@@ -112,11 +112,15 @@ SharePoint is a popular option for data storage for Power Apps, due to not needi
 
 It is worth noting that SharePoint can be customised to suit many business needs, but it is important to weigh up the development effort involved, as this can often outweigh the cost of buying premium licencing.
 
+
 # Security Best Practices
 
 ## Environment Security Groups
 
 Every environment, without exception, should be assigned a security group – failure to assign a security group will mean that the entire tenant can access the environment.
+
+## Security Roles
+When creating security roles ensure the naem of the security role is indicative of the tables/solution the security role is being used in alongside the level of access being provided for example "Expenses App - Admin" 
 
 ## App Security Groups
 

--- a/Dataverse.md
+++ b/Dataverse.md
@@ -120,7 +120,7 @@ It is worth noting that SharePoint can be customised to suit many business needs
 Every environment, without exception, should be assigned a security group – failure to assign a security group will mean that the entire tenant can access the environment.
 
 ## Security Roles
-When creating security roles ensure the naem of the security role is indicative of the tables/solution the security role is being used in alongside the level of access being provided for example "Expenses App - Admin" 
+When creating security roles ensure the name of the security role is indicative of the tables/solution the security role is being used in alongside the level of access being provided for example "Expenses App - Admin" 
 
 ## App Security Groups
 

--- a/PowerAutomate.md
+++ b/PowerAutomate.md
@@ -130,10 +130,11 @@ When one action in a scope fails, the entire scope will fail, this can be useful
 
 ## Error Handling
 
-Code first developers often make use of the try-catch approach when dealing with error handling, this can be achieved in cloud flows using scope actions and run after (more info on run after can be found at [Configure run after option - Training | Microsoft Learn](https://learn.microsoft.com/en-us/training/modules/error-handling/2-configure-run-after))
+Code first developers often make use of the try-catch-finally approach when dealing with error handling, this can be achieved in cloud flows using scope actions and run after (more info on run after can be found at [Configure run after option - Training | Microsoft Learn](https://learn.microsoft.com/en-us/training/modules/error-handling/2-configure-run-after))
 
 - “Scope One” contains the actions you are trying to do (“try”)
 - “Scope two” contains your error handling and is set to run after “Scope One” fails or times out (i.e. not if it succeeds, or is skipped) you could send an email to a support team, or post a message in a teams chat or channel, the actions in the catch scope will vary from project to project, but the overall theme is the same – telling someone that a business critical flow has not successfully completed so they can take the necessary action to ensure business continuity.
+- "Scope Three" contains the actions that must occur regardless of the success or failure of the other two scopes
 
 ## Child Flows
 
@@ -144,6 +145,9 @@ A common use case for child flows is sending of emails with a specific format, o
 Child flows have a manual trigger (with optional inputs) and should end with a respond to app or flow action (to provide an output to the parent flow).
 
 An example child flow might accept a date of birth as an input, calculate age of the person in years and months based on today’s date, and return this value in a defined format to a parent app or flow.
+
+For ease of tracking it is recommended that one of the inputs of the child flow be the URL to the parent flow that triggered the child flow. This can be acheived by using the following expression in the inputs when calling the child flow:
+concat('https://make.powerautomate.com/environments/', workflow()?['tags']['environmentName'], '/flows/', workflow()?['name'], '/runs/', workflow()?['run']['name'])
 
 Further information about child flows can be found at [Create child Flows - Power Automate | Microsoft Learn](https://learn.microsoft.com/en-us/power-automate/create-child-flows)
 


### PR DESCRIPTION
Good Evening Stuart,

Made some updates to the following docs:

- Power Automate Best Practice
    - Added a section in error handling to add the finally scope
    - Added a section in Child flows to refer to adding the parent flow run link as a required input to ensure ease of tracking between             parent/child flow runs
- Power Apps Best Practice
    - Added more control prefixes
    - Added a section in variable naming convention to define data type in variable name
    - Updated data type table in variables section
- Dataverse Best Practice
    - Added a section on naming security roles


Will Johnson
